### PR TITLE
fix: flush async batches with an independent timer

### DIFF
--- a/src/greptimedb_worker.erl
+++ b/src/greptimedb_worker.erl
@@ -24,7 +24,7 @@
 -export([start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, async_handle/3]).
 -export([connect/1]).
 
--record(state, {channel, requests, hints}).
+-record(state, {channel, requests, hints, batch_timer = undefined}).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -104,17 +104,19 @@ handle_call(channel, _From, #state{channel = Channel} = State) ->
 handle_info(?ASYNC_REQ(Request, ExpireAt, ResultCallback), State0) ->
     Req = ?REQ(Request, ExpireAt),
     State1 = enqueue_req(ResultCallback, Req, State0),
-    State = maybe_shoot(State1, false),
-    noreply_state(State);
+    State = update_batch_timer(maybe_shoot(State1, false)),
+    {noreply, State};
 
-handle_info(timeout, State0) ->
-    State = maybe_shoot(State0, true),
-    noreply_state(State);
+handle_info({timeout, TRef, flush_batch}, #state{batch_timer = TRef} = State0) ->
+    State1 = maybe_shoot(State0#state{batch_timer = undefined}, true),
+    {noreply, update_batch_timer(State1)};
+handle_info({timeout, _TRef, flush_batch}, State) ->
+    {noreply, State};
 
 handle_info(Info, State) ->
     logger:debug("~p unexpected_info: ~p, channel: ~p", [?MODULE, Info, State#state.channel]),
 
-    {noreply, State, ?ASYNC_BATCH_LINGER}.
+    {noreply, State}.
 
 
 start_link(Args) ->
@@ -181,11 +183,22 @@ reply({F, A}, Result) when is_function(F) ->
 reply(From, Result) ->
     gen_server:reply(From, Result).
 
-noreply_state(#state{requests = #{pending_count := N}} = State) when N > 0 ->
-    {noreply, State, ?ASYNC_BATCH_LINGER};
+update_batch_timer(#state{requests = #{pending_count := 0}} = State) ->
+    cancel_batch_timer(State);
+update_batch_timer(#state{requests = #{pending_count := N}} = State) when N > 0 ->
+    start_batch_timer(State).
 
-noreply_state(State) ->
-    {noreply, State}.
+start_batch_timer(#state{batch_timer = undefined} = State) ->
+    TRef = erlang:start_timer(?ASYNC_BATCH_LINGER, self(), flush_batch),
+    State#state{batch_timer = TRef};
+start_batch_timer(State) ->
+    State.
+
+cancel_batch_timer(#state{batch_timer = TRef} = State) when is_reference(TRef) ->
+    _ = erlang:cancel_timer(TRef),
+    State#state{batch_timer = undefined};
+cancel_batch_timer(State) ->
+    State.
 
 
 %%%===================================================================

--- a/test/greptimedb_SUITE.erl
+++ b/test/greptimedb_SUITE.erl
@@ -20,6 +20,8 @@ all() ->
      t_bench_perf,
      t_write_stream,
      t_async_write_batch,
+     t_async_batch_timer_lifecycle,
+     t_async_write_after_health_check,
      t_write_greptime_cloud,
      t_auth_error,
      t_insert_requests,
@@ -260,7 +262,7 @@ t_write_failure(_) ->
         %% the port 5001 is invalid
         [{endpoints, [{http, greptime_host(), 5001}]},
          {pool, greptimedb_client_pool},
-         {pool_size, 5},
+         {pool_size, 1},
          {pool_type, random},
          {auth, {basic, #{username => ?GREPTIME_USERNAME, password => ?GREPTIME_PASSWORD}}}],
 
@@ -268,18 +270,31 @@ t_write_failure(_) ->
     false = greptimedb:is_alive(Client),
     {error, _} = greptimedb:write(Client, Metric, Points),
 
-    %% async write
+    %% The batch timer must be restarted for requests left after the first failure.
     Ref = make_ref(),
     TestPid = self(),
     ResultCallback = {fun(Reply) -> TestPid ! {{Ref, reply}, Reply} end, []},
 
-    ok = greptimedb:async_write(Client, Metric, Points, ResultCallback),
-    receive
-        {{Ref, reply}, {error, Error}} ->
-            ct:print("write failure: ~p", [Error]);
-        {{Ref, reply}, _Other} ->
-            ?assert(false)
-    end,
+    [{_, PoolWorker}] = ecpool:workers(greptimedb_client_pool),
+    {ok, Worker} = ecpool_worker:client(PoolWorker),
+    with_suspended_worker(
+      Worker,
+      fun() ->
+          ok = greptimedb:async_write(Client, Metric, Points, ResultCallback),
+          ok = greptimedb:async_write(Client, Metric, Points, ResultCallback)
+      end),
+    lists:foreach(
+      fun(_) ->
+          receive
+              {{Ref, reply}, {error, Error}} ->
+                  ct:print("write failure: ~p", [Error]);
+              {{Ref, reply}, Other} ->
+                  ct:fail({unexpected_async_write_result, Other})
+          after 5000 ->
+              ct:fail(async_write_failure_not_retried)
+          end
+      end,
+      lists:seq(1, 2)),
 
     greptimedb:stop_client(Client),
     ok.
@@ -698,6 +713,139 @@ t_async_write_batch(_) ->
 
     greptimedb:stop_client(Client),
     ok.
+
+t_async_batch_timer_lifecycle(_) ->
+    Pool = iolist_to_binary([
+        "greptimedb_batch_timer_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    Options =
+        [{endpoints, [{http, greptime_host(), 4001}]},
+         {pool, Pool},
+         {pool_size, 1},
+         {pool_type, random},
+         {auth, {basic, #{username => ?GREPTIME_USERNAME, password => ?GREPTIME_PASSWORD}}}],
+    {ok, Client} = greptimedb:start_client(Options),
+    try
+        [{_, PoolWorker}] = ecpool:workers(Pool),
+        {ok, Worker} = ecpool_worker:client(PoolWorker),
+        Request =
+            greptimedb_encoder:insert_requests(
+              Client,
+              [{<<"async_batch_timer">>,
+                [#{fields => #{<<"value">> => 1.0},
+                   tags => #{<<"source">> => <<"batch_timer">>},
+                   timestamp => erlang:system_time(millisecond)}]}]),
+        Ref = make_ref(),
+        TestPid = self(),
+        ResultCallback = {fun(Reply) -> TestPid ! {Ref, Reply} end, []},
+
+        with_suspended_worker(
+          Worker,
+          fun() ->
+              lists:foreach(
+                fun(_) ->
+                    ok = greptimedb_worker:async_handle(Worker, Request, ResultCallback)
+                end,
+                lists:seq(1, 200))
+          end),
+        recv_async_results(Ref, 200),
+        with_suspended_worker(
+          Worker,
+          fun() ->
+              {state, _Channel, #{pending_count := 0}, _Hints, undefined} =
+                  sys:get_state(Worker)
+          end),
+
+        StaleTRef = make_ref(),
+        ok = greptimedb_worker:async_handle(Worker, Request, ResultCallback),
+        Worker ! {timeout, StaleTRef, flush_batch},
+        with_suspended_worker(
+          Worker,
+          fun() ->
+              {state, _Channel, #{pending_count := 1}, _Hints, NewTRef} =
+                  sys:get_state(Worker),
+              true = is_reference(NewTRef),
+              false = NewTRef =:= StaleTRef
+          end),
+        recv_async_results(Ref, 1)
+    after
+        greptimedb:stop_client(Client)
+    end.
+
+recv_async_results(_Ref, 0) ->
+    ok;
+recv_async_results(Ref, N) ->
+    receive
+        {Ref, {ok, _}} ->
+            recv_async_results(Ref, N - 1);
+        {Ref, Error} ->
+            ct:fail({async_write_failed, Error})
+    after 5000 ->
+        ct:fail({async_write_results_missing, N})
+    end.
+
+with_suspended_worker(Worker, Fun) ->
+    ok = sys:suspend(Worker),
+    try
+        Fun()
+    after
+        ok = sys:resume(Worker)
+    end.
+
+t_async_write_after_health_check(_) ->
+    Pool = iolist_to_binary([
+        "greptimedb_health_check_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    Options =
+        [{endpoints, [{http, greptime_host(), 4001}]},
+         {pool, Pool},
+         {pool_size, 1},
+         {pool_type, random},
+         {auth, {basic, #{username => ?GREPTIME_USERNAME, password => ?GREPTIME_PASSWORD}}}],
+    {ok, Client} = greptimedb:start_client(Options),
+    try
+        Ref = make_ref(),
+        TestPid = self(),
+        [{_, PoolWorker}] = ecpool:workers(Pool),
+        {ok, Worker} = ecpool_worker:client(PoolWorker),
+        ResultCallback = {fun(Reply) -> TestPid ! {Ref, Reply} end, []},
+        Points =
+            [#{fields => #{<<"value">> => 1.0},
+               tags => #{<<"source">> => <<"health_check">>},
+               timestamp => erlang:system_time(millisecond)}],
+        ok = greptimedb:async_write(Client, <<"async_health_check">>, Points, ResultCallback),
+        true = greptimedb:is_alive(Client),
+        Deadline = erlang:monotonic_time(millisecond) + 2000,
+        Flood =
+            fun F() ->
+                case erlang:monotonic_time(millisecond) < Deadline of
+                    true ->
+                        _ = sys:get_state(Worker),
+                        F();
+                    false ->
+                        TestPid ! {Ref, flood_done}
+                end
+            end,
+        spawn(Flood),
+        receive
+            {Ref, {ok, _}} ->
+                ok;
+            {Ref, flood_done} ->
+                ct:fail(async_write_delayed_by_worker_messages);
+            {Ref, Error} ->
+                ct:fail({async_write_failed, Error})
+        after 5000 ->
+            ct:fail(async_write_not_flushed)
+        end,
+        receive
+            {Ref, flood_done} ->
+                ok
+        after 3000 ->
+            ct:fail(worker_message_flood_not_finished)
+        end
+    after
+        greptimedb:stop_client(Client)
+    end.
 
 t_write_greptime_cloud(_) ->
     Host = os:getenv("GT_TEST_HOST"),


### PR DESCRIPTION
## Problem

Async batches used the `gen_server` inactivity timeout as their 20 ms linger timer. Processing a health-check call cancels that timeout, and the health-check callback returns without rearming it. If no later async write arrives, the pending batch is never flushed.

This is more likely to surface at low TPS because there may be no subsequent write to restart the timeout or reach the batch-size threshold.

## Impact

The async result callback can remain pending until another write arrives. In EMQX, the action request may exceed its request TTL first, producing `late_reply`, `request_expired`, and dropped-expired-message metrics or alerts even when the network is healthy and there is no queue buildup.

## Fix

Use an independent Erlang timer for each non-empty batch. Start it when the first request is queued, cancel it after the batch is fully flushed, and rearm it when a failed flush leaves requests pending. Match timer references so that a canceled timer message cannot flush a newer batch.

The tests cover health-check interference, size-triggered flush and timer cleanup, stale timer messages, and rearming after a stream failure.